### PR TITLE
Fix metric name in RealtimeMonitor

### DIFF
--- a/src/components/RealtimeMonitor.tsx
+++ b/src/components/RealtimeMonitor.tsx
@@ -12,7 +12,7 @@ const RealtimeMonitor: React.FC = () => {
   const [metrics, setMetrics] = useState<MetricData[]>([
     { name: 'API 응답시간', value: 245, unit: 'ms', status: 'good', trend: 'stable' },
     { name: 'CPU 사용률', value: 34, unit: '%', status: 'good', trend: 'down' },
-    { name: ' 메모리 사용률', value: 67, unit: '%', status: 'warning', trend: 'up' },
+    { name: '메모리 사용률', value: 67, unit: '%', status: 'warning', trend: 'up' },
     { name: '활성 테스트', value: 12, unit: '개', status: 'good', trend: 'stable' }
   ]);
 


### PR DESCRIPTION
## Summary
- fix the memory usage metric name in `RealtimeMonitor`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_687585d5d8a4832b99ef2743763ed903